### PR TITLE
Updated readme with the correct requirement file

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -22,7 +22,7 @@ First, make sure you have a local redis instance running. The engine expects to 
 
 You'll also need [Anaconda](https://www.continuum.io/downloads) installed (a scientific distribution of Python). Create a new virtualenv with the needed dependencies:
 
-> conda create -n crec --file conda.txt
+> conda create -n crec --file conda-requirements.txt
 
 Now, in the virtualenv (``source activate crec``):
 


### PR DESCRIPTION
The previous file `conda.txt` is no longer available, so it returns an error. So, updated the doc with the appropriate conda requirements file.